### PR TITLE
Show language display names and render missing values in card view

### DIFF
--- a/app.js
+++ b/app.js
@@ -105,12 +105,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
             // Use activeCardLanguages for the main grid
             // Any language NOT in activeCardLanguages but present in data goes to "Show all"
-            const primaryLangs = activeCardLanguages.filter(l => fish.names[l]);
-            const otherLangs = SUPPORTED_LANGUAGES.filter(l => !activeCardLanguages.includes(l) && fish.names[l]);
+            const primaryLangs = [...activeCardLanguages];
+            const otherLangs = SUPPORTED_LANGUAGES.filter(l => !activeCardLanguages.includes(l));
 
             const renderGrid = (langs) => langs.map(lang => `
                 <div class="lang-group">
-                    <span class="lang-label">${lang}</span>
+                    <span class="lang-label">${LANGUAGE_DISPLAY_NAMES[lang] || lang.charAt(0).toUpperCase() + lang.slice(1)}</span>
                     <span class="lang-value">${fish.names[lang] ? fish.names[lang].join(' / ') : '-'}</span>
                 </div>
             `).join('');


### PR DESCRIPTION
### Motivation

- Make card view language labels user-friendly by showing display names instead of raw keys to match UI expectations.
- Ensure configured languages are always shown in the primary grid so missing translations render consistently as a placeholder.
- Preserve the ability to view the remaining languages in the expandable "Show all languages" section.

### Description

- Change `primaryLangs` to include all `activeCardLanguages` so selected columns appear even when a fish lacks that language entry. 
- Change `otherLangs` to include all `SUPPORTED_LANGUAGES` not in `activeCardLanguages` so the "Show all languages" list is complete. 
- Render language labels using `LANGUAGE_DISPLAY_NAMES` (falling back to a capitalized key) instead of the raw language key. 
- Keep missing name rendering as `'-'` by using the existing ternary that joins `fish.names[lang]` or shows `'-'`.

### Testing

- Started a local server with `python -m http.server 8000` and the server started successfully. 
- Ran a Playwright script using `playwright.sync_api` to open `http://localhost:8000/` and capture a screenshot, which completed successfully and produced `artifacts/card-view-language-labels.png`. 
- No automated unit or integration test suites from the repo were executed as part of this change. 
- The change was committed with message `Fix card language labels and missing values` and recorded in the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952067ce5ec8321966fb1c84b4c7b9e)