### PR TITLE
Improve accessibility for search input and languages dialog

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,6 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         btnCustomizeCols.addEventListener('click', () => {
             colDialog.hidden = !colDialog.hidden;
+            btnCustomizeCols.setAttribute('aria-expanded', String(!colDialog.hidden));
             if (!colDialog.hidden) {
                 renderColumnSelector();
             }
@@ -84,6 +85,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         btnCloseCols.addEventListener('click', () => {
             colDialog.hidden = true;
+            btnCustomizeCols.setAttribute('aria-expanded', 'false');
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -28,15 +28,16 @@
         <div class="header-content">
             <h1>Indian Fish Name Guide</h1>
             <div class="search-container">
+                <label for="search-input" class="sr-only">Search fish names</label>
                 <input type="text" id="search-input" placeholder="Search fish, synonyms, or languages...">
                 <span class="search-icon">🔍</span>
             </div>
 
 
             <div id="view-controls">
-                <button id="btn-customize-cols" class="secondary-btn">🌐 Languages</button>
-                <div id="column-selector-dialog" hidden>
-                    <h3>Show Languages</h3>
+                <button id="btn-customize-cols" class="secondary-btn" aria-controls="column-selector-dialog" aria-expanded="false">🌐 Languages</button>
+                <div id="column-selector-dialog" role="dialog" aria-labelledby="column-selector-title" hidden>
+                    <h3 id="column-selector-title">Show Languages</h3>
                     <div id="column-checkboxes"></div>
                     <button id="btn-close-cols" class="secondary-btn">Done</button>
                 </div>

--- a/style.css
+++ b/style.css
@@ -246,6 +246,18 @@ h1 {
     border: 1px solid var(--border-color);
 }
 
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 
 
 /* Utilities */


### PR DESCRIPTION
### Motivation
- Improve keyboard and screen-reader accessibility for the main search input and the language selector dialog. 
- Provide semantic dialog attributes so assistive tech can identify and announce the language selector. 
- Ensure the visible UI behavior and state are reflected with ARIA attributes for better a11y tooling.

### Description
- Added a visually hidden label for the search input using a new `.sr-only` utility class in `style.css` and a `<label>` in `index.html`.
- Marked the language selector as a dialog with `role="dialog"` and connected its heading via `aria-labelledby` in `index.html`.
- Added `aria-controls` and `aria-expanded` to the Languages button and updated `app.js` to keep `aria-expanded` in sync when opening/closing the dialog.
- Created the `.sr-only` CSS rule in `style.css` to provide a reusable screen-reader-only utility.

### Testing
- No automated tests were executed as part of this change because it is a static accessibility enhancement.
- The app still loads existing `data/fish.json` and rendering behavior is unchanged according to local inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952111b7e60832197c832194d4b08e8)