### PR TITLE
Document Netlify SPA redirect guidance and add `netlify.toml`

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -214,7 +214,7 @@ Each card includes a share button that:
 ## Deployment
 
 ### Supported Platforms
-- **Netlify** (recommended) - Automatic SPA routing
+- **Netlify** (recommended) - Automatic SPA routing (ensure `netlify.toml` includes SPA redirect)
 - **Vercel** - Built-in SPA support
 - **Cloudflare Pages** - SPA routing enabled
 - **GitHub Pages** - Requires `404.html` workaround
@@ -222,6 +222,15 @@ Each card includes a share button that:
 
 ### Build Commands
 No build step required. Deploy all files as-is.
+
+### Netlify SPA Redirect
+Include a `netlify.toml` at the repo root so deep links resolve to the SPA entrypoint:
+```toml
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+```
 
 ### Important Files for Deployment
 - `sitemap.xml` - Submit to Google Search Console

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/product/spec.md
+++ b/product/spec.md
@@ -82,6 +82,15 @@ No build system required. The app runs in two modes:
 - **Development**: `npm start` (Node.js server with hot reload)
 - **Production**: Deploy to static hosting with SPA fallback configured
 
+**Netlify SPA Redirect**:
+Add a `netlify.toml` at the repo root so Netlify serves `index.html` for deep links:
+```toml
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+```
+
 ---
 
 ## **5. Data Model**


### PR DESCRIPTION
### Motivation
- Ensure deep links and browser refreshes resolve to the SPA entrypoint when deploying to Netlify.
- Make the required Netlify configuration explicit in both developer-facing docs and the product specification.
- Provide an example `netlify.toml` so contributors can deploy the static site with SPA fallback correctly.

### Description
- Add `netlify.toml` at the repository root with a `[[redirects]]` block that maps `from = "/*"` to `to = "/index.html"` with `status = 200`.
- Update `agent.md` to mention Netlify SPA routing and include the `netlify.toml` example snippet.
- Update `product/spec.md` to document the Netlify SPA redirect and show the same `netlify.toml` snippet for production deployments.
- This is a documentation and configuration change to enable correct SPA behavior on Netlify hosts.

### Testing
- No automated tests were added or executed because this is a documentation/configuration change.
- The change is documentation-only and does not modify application logic or runtime behavior in code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69535963d7e08321b1d197e7d64df5ea)