### PR TITLE
Set Agathi keerai scientific name to Sesbania grandiflora and revert image

### DIFF
--- a/data/vegetables-fruits.json
+++ b/data/vegetables-fruits.json
@@ -8474,7 +8474,7 @@
     "tags": [
       "leafy"
     ],
-    "scientificName": "N/A",
+    "scientificName": "Sesbania grandiflora",
     "names": {
       "english": [
         "Agathi Keerai"


### PR DESCRIPTION
### Motivation
- Correct the species information for `agathi-keerai` by replacing the placeholder `N/A` with the accurate binomial name.
- Revert the previously changed image for `agathi-keerai` while preserving the metadata update.
- Improve data quality and consistency in the `data/vegetables-fruits.json` dataset.

### Description
- Updated `data/vegetables-fruits.json` for the item with `id: "agathi-keerai"` to set `scientificName` to `"Sesbania grandiflora"`.
- Reverted `img/agathi-keerai.webp` to the prior version using `git checkout HEAD~1 -- img/agathi-keerai.webp` and committed the revert.
- No other item fields were modified and other dataset entries were left intact.

### Testing
- Ran a JSON inspection with `node -e "const fs=require('fs');const data=JSON.parse(fs.readFileSync('data/vegetables-fruits.json','utf8'));const item=data.find(x=>x.id==='agathi-keerai');console.log(item);"` and confirmed the `scientificName` is `Sesbania grandiflora`.
- Ran a sample extraction with `node -e "const fs=require('fs');const data=JSON.parse(fs.readFileSync('data/vegetables-fruits.json','utf8'));console.log(data.filter(x=>x.scientificName&&x.scientificName!=='N/A').slice(0,10).map(x=>x.scientificName));"` to spot-check other entries and it completed successfully.
- No automated unit or E2E test suites (for example `npm test`) were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954a1a79f188321a0220760b20250dc)