### PR TITLE
Fix Hindi potato name entry

### DIFF
--- a/data/vegetables-fruits.json
+++ b/data/vegetables-fruits.json
@@ -14,8 +14,8 @@
         "Urulakizhangu"
       ],
       "hindi": [
-        "Aloo",
-        "Alu"
+        "आलू",
+        "Aloo"
       ],
       "kannada": [
         "ಆಲೂಗಡ್ಡೆ",


### PR DESCRIPTION
### Motivation
- The Hindi `names` entry for the potato contained Latin-script forms instead of the Devanagari primary form. 
- Ensure the Hindi name uses native Devanagari script while retaining a transliteration.

### Description
- Updated `data/vegetables-fruits.json` for the entry with `id: "potato"` to replace `"Aloo", "Alu"` with `"आलू", "Aloo"` under `names.hindi`.
- Preserved the transliteration while adding the correct Devanagari representation.
- Saved and committed the change to the repository.

### Testing
- No automated tests were run for this change.
- The modified file was inspected and committed successfully (`git commit` completed without errors`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69554b12b20c8321a41952152d389f0e)