### PR TITLE
fix(flowers): correct Kannada name for lantana

### DIFF
--- a/src/data/flowers.json
+++ b/src/data/flowers.json
@@ -1856,8 +1856,8 @@
                 "Raimuniya"
             ],
             "kannada": [
-                "ರೋಜಾ",
-                "Roja"
+                "ಚದುರಂಗಿ",
+                "Chadurangi"
             ],
             "malayalam": [
                 "കൊങ്ങിണി",


### PR DESCRIPTION
### Motivation
- Correct an incorrect Kannada entry for the `lantana` item in the flowers dataset to ensure accurate translations in the app.

### Description
- Updated the Kannada `names` entry for `lantana` in `src/data/flowers.json`, replacing `ರೋಜಾ (Roja)` with `ಚದುರಂಗಿ (Chadurangi)`, and noted that the sitemap must be regenerated per project rules using `python3 scripts/generate_sitemap.py` before deployment.

### Testing
- Ran the targeted data integrity suite with `npm test -- tests/data_integrity.test.js` and all tests passed (16/16).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991dca404dc8321a425ed502a187caa)