### PR TITLE
Update Kannada common names for Lantana in flowers dataset

### DIFF
--- a/src/data/flowers.json
+++ b/src/data/flowers.json
@@ -1856,8 +1856,14 @@
                 "Raimuniya"
             ],
             "kannada": [
-                "ಚದುರಂಗಿ",
-                "Chadurangi"
+                "ಚದುರಂಗ",
+                "Chaduranga",
+                "ಕಾಡು ಗುಲಾಬಿ",
+                "Kaadu Gulabi",
+                "ಕಸೂತಿ ಹೂವು",
+                "Kasuti Huvu",
+                "ಚಿತ್ರಾಂಗಿ",
+                "Chitrangi"
             ],
             "malayalam": [
                 "കൊങ്ങിണി",


### PR DESCRIPTION
### Motivation
- Improve and expand the Kannada common name entries for the Lantana record in `src/data/flowers.json` to better reflect local name variants and transliterations.

### Description
- Replaced and extended the `kannada` names array for the `lantana` entry in `src/data/flowers.json` with corrected spellings and additional local name variants and transliterations.

### Testing
- No automated tests were run for this data-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fafd8072608321b87b1f9aec79d70d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk data-only change that updates a single flower record’s localized names; main risk is downstream consumers relying on exact Kannada strings/order.
> 
> **Overview**
> Updates the `lantana` entry in `src/data/flowers.json` by correcting the Kannada common name spelling (`ಚದುರಂಗಿ` -> `ಚದುರಂಗ`) and expanding the Kannada names list with additional local variants and their transliterations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1090f2027a2cf7cb26a2b2588a25691a99b5dbaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->